### PR TITLE
Update .eslintignore to ignore all files with .config.* extension

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 /dist
-**/*.config.*
+*.config.*


### PR DESCRIPTION
This pull request updates the .eslintignore file to ignore all files with the .config.* extension. This will ensure that these files are not included in the ESLint checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Chores:
- Adjusted the file exclusion pattern in the `.eslintignore` file. Previously, only files with a `.config.*` extension in the `/dist` directory were ignored. Now, any file with a `*.config.*` extension in the same directory will be ignored. This change broadens the range of files that are excluded from linting, ensuring a cleaner and more efficient codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->